### PR TITLE
fix(#43): delete only untagged versions

### DIFF
--- a/.github/workflows/registry_retention.yml
+++ b/.github/workflows/registry_retention.yml
@@ -15,5 +15,4 @@ jobs:
           package-name: 'postthis'
           package-type: 'container'
           min-versions-to-keep: 10
-          delete-only-untagged-versions: 'false'
-          ignore-versions: '^(0|[0-9]\\d*)\\.0\\.0$'
+          delete-only-untagged-versions: 'true'


### PR DESCRIPTION
set delete-only-untagged-versions to true instead of using ignore-versions